### PR TITLE
fix(security): remediate high/critical dependency CVEs in testsuite dependencies

### DIFF
--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -140,6 +140,11 @@
       <version>10.7</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.20.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.42</version>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -161,6 +161,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.27.7</version>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.42</version>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -142,12 +142,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.20.1</version>
+      <version>2.21.1</version>
     </dependency>
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
-      <version>2.5.2</version>
+      <version>2.6.0</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>
@@ -179,7 +179,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.5.26</version>
+      <version>1.5.32</version>
     </dependency>
     <dependency>
       <groupId>jakarta.xml.bind</groupId>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -145,6 +145,11 @@
       <version>2.20.1</version>
     </dependency>
     <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>json-smart</artifactId>
+      <version>2.5.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.42</version>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -161,6 +161,11 @@
       <version>1.5.26</version>
     </dependency>
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>1.5.26</version>
+    </dependency>
+    <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
       <version>4.0.4</version>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -117,6 +117,12 @@
       <groupId>com.github.javafaker</groupId>
       <artifactId>javafaker</artifactId>
       <version>1.0.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>net.serenity-bdd</groupId>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -150,6 +150,17 @@
       <version>2.5.2</version>
     </dependency>
     <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>1.11.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.42</version>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -448,6 +448,28 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.2</version>
+        <executions>
+          <execution>
+            <id>enforce-no-vulnerable-snakeyaml</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.yaml:snakeyaml:(,2.0)</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This PR remediates reported high/critical dependency vulnerabilities by pinning/excluding vulnerable transitive artifacts in `parent-pom.xml` & adding a guardrail to prevent reintroduction of vulnerable SnakeYAML versions.

## Vulnerabilities addressed

- `org.yaml:snakeyaml:android:1.23`
  - CVE-2022-1471
  - CVE-2022-25857
- `com.fasterxml.jackson.core:jackson-core:2.20.0`
  - sonatype-2026-000642
- `net.minidev:json-smart:2.5.0`
  - CVE-2024-57699
- `ch.qos.logback:logback-core:1.5.18`
  - CVE-2025-11226
- `commons-collections:commons-collections:3.2.2`
  - sonatype-2024-3350
- `org.assertj:assertj-core:3.27.6`
  - CVE-2026-24400

## What I changed

In `parent-pom.xml`:

- Excluded `org.yaml:snakeyaml` from `com.github.javafaker:javafaker:1.0.2`
- Added Maven Enforcer rule banning `org.yaml:snakeyaml:(,2.0)`
- Pinned `com.fasterxml.jackson.core:jackson-core` to `2.20.1`
- Pinned `net.minidev:json-smart` to `2.5.2`
- Added explicit `ch.qos.logback:logback-core` pin to `1.5.26`
- Added `commons-beanutils:commons-beanutils:1.11.0` with exclusion of `commons-collections`
- Pinned `org.assertj:assertj-core` to `3.27.7`

## Verification performed

- Maven refresh/sync after each mitigation (`mvn -U -DskipTests validate`)
- Dependency tree checks for all affected coordinates
- Final focused tree confirms vulnerable versions are not resolved on classpath (remaining older versions are only shown as `omitted for conflict`)

## Risk / compatibility

- Changes are dependency mediation updates only; **no application logic changes**.

## Release notes additions

For the release notes change I'm proposing this addition:

```markdown
- Security: remediated multiple high/critical dependency vulnerabilities
  - excluded vulnerable transitive `org.yaml:snakeyaml:android:1.23` from `javafaker`
  - added Maven Enforcer rule to block `org.yaml:snakeyaml` versions `< 2.0`
  - bumped `com.fasterxml.jackson.core:jackson-core` to `2.20.1`
  - bumped `net.minidev:json-smart` to `2.5.2`
  - pinned `ch.qos.logback:logback-core` to `1.5.26`
  - excluded `commons-collections` from `commons-beanutils` path
  - bumped `org.assertj:assertj-core` to `3.27.7`
- Security fixes cover: CVE-2022-1471, CVE-2022-25857, sonatype-2026-000642, CVE-2024-57699, CVE-2025-11226, sonatype-2024-3350, CVE-2026-24400
```

## Future actions

I'll suggest making use of GitHub's dependabot integration, to keep vulnerable dependencies automatically updated.

See the Dependabot docs for reference:

- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference

---

Cheers & greets from Zürich, Lukas