### PR TITLE
fix(build): replace exec-maven-plugin with maven-antrun-plugin for report saving

### DIFF
--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -25,7 +25,6 @@
     <serenity.core.version>5.3.10</serenity.core.version>
     <polarion.toolbox.version>3.0.3-212</polarion.toolbox.version>
     <ti.m.mtls.certs.version>2.2.4</ti.m.mtls.certs.version>
-    <maven.exec.plugin.version>3.6.3</maven.exec.plugin.version>
     <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
     <maven.dependency.plugin.version>3.9.0</maven.dependency.plugin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -254,11 +254,10 @@
           </execution>
         </executions>
       </plugin>
-      <!--      Done with "cp" to keep timestamp-->
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>${maven.exec.plugin.version}</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
         <configuration>
           <skip>${skip.saving.reports}</skip>
         </configuration>
@@ -267,16 +266,14 @@
             <id>save_reports</id>
             <phase>post-integration-test</phase>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
             <configuration>
-              <executable>cp</executable>
-              <arguments>
-                <argument>-a</argument>
-                <argument>${project.build.directory}/site/serenity/.</argument>
-                <!--suppress UnresolvedMavenProperty -->
-                <argument>${basedir}/reports/${build.time}/report/</argument>
-              </arguments>
+              <target>
+                <copy todir="${basedir}/reports/${build.time}/report/" preservelastmodified="true">
+                  <fileset dir="${project.build.directory}/site/serenity"/>
+                </copy>
+              </target>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Removed the exec-maven-plugin and updated the build process to use the maven-antrun-plugin for copying Serenity reports.  

This change simplifies the report saving mechanism and ensures better compatibility with the build lifecycle.

- switch report archiving to a platform-independent build step
- keep last-modified timestamps during copy to preserve report metadata
- remove the now-unused version property tied to the old external command
- unblock local runs and CI jobs on Windows without extra shell tooling
- make post-test report export work the same across Windows and Unix

Fixes #95.